### PR TITLE
Removed unused junctions parameter in circuit init

### DIFF
--- a/src/Circuit.py
+++ b/src/Circuit.py
@@ -11,13 +11,12 @@ class Circuit(object):
     information about their connections and properties
     """
     ###########################################################################
-    def __init__(self, junctions=[]):
+    def __init__(self):
         """
         DESCRIPTION
         PARAMETERS
         RETURNS
         """
-        self.junctions = junctions
         self.node_map = {}
 
     ###########################################################################


### PR DESCRIPTION
Seems to violate some kind of abstraction to have a junctions init parameter, since I've designed the circuit model to assign junctions as necessary